### PR TITLE
SCRUM-222

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,7 +11,7 @@
   --card-foreground: oklch(0.141 0.005 285.823);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.24 0.06 240); /* #003153 */
+  --primary: oklch(0.35 0.15 27); /* #8B0000 dark red */
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
@@ -32,10 +32,10 @@
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.24 0.06 240); /* #003153 */
+  --sidebar-primary: oklch(0.35 0.15 27); /* #8B0000 dark red */
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.24 0.06 240); /* #003153 */
+  --sidebar-accent-foreground: oklch(0.35 0.15 27); /* #8B0000 dark red */
   --sidebar-border: oklch(0.92 0.004 286.32);
   --sidebar-ring: oklch(0.705 0.015 286.067);
 }
@@ -47,7 +47,7 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.141 0.005 285.823);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.24 0.06 240); /* #003153 */
+  --primary: oklch(0.35 0.15 27); /* #8B0000 dark red */
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
@@ -67,7 +67,7 @@
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.24 0.06 240); /* #003153 */
+  --sidebar-primary: oklch(0.35 0.15 27); /* #8B0000 dark red */
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.274 0.006 286.033);
   --sidebar-accent-foreground: oklch(0.985 0 0);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,7 +11,7 @@
   --card-foreground: oklch(0.141 0.005 285.823);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.21 0.006 285.885);
+  --primary: oklch(0.27 0.07 245);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
@@ -32,10 +32,10 @@
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary: oklch(0.27 0.07 245);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-accent-foreground: oklch(0.27 0.07 245);
   --sidebar-border: oklch(0.92 0.004 286.32);
   --sidebar-ring: oklch(0.705 0.015 286.067);
 }
@@ -47,8 +47,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.141 0.005 285.823);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.21 0.006 285.885);
+  --primary: oklch(0.45 0.12 245);
+  --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.274 0.006 286.033);
@@ -67,7 +67,7 @@
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary: oklch(0.45 0.12 245);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.274 0.006 286.033);
   --sidebar-accent-foreground: oklch(0.985 0 0);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,7 +11,7 @@
   --card-foreground: oklch(0.141 0.005 285.823);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.27 0.07 245);
+  --primary: oklch(0.24 0.06 240); /* #003153 */
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
@@ -32,10 +32,10 @@
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.27 0.07 245);
+  --sidebar-primary: oklch(0.24 0.06 240); /* #003153 */
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.27 0.07 245);
+  --sidebar-accent-foreground: oklch(0.24 0.06 240); /* #003153 */
   --sidebar-border: oklch(0.92 0.004 286.32);
   --sidebar-ring: oklch(0.705 0.015 286.067);
 }
@@ -47,7 +47,7 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.141 0.005 285.823);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.45 0.12 245);
+  --primary: oklch(0.24 0.06 240); /* #003153 */
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
@@ -67,7 +67,7 @@
   --chart-5: oklch(0.645 0.246 16.439);
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.45 0.12 245);
+  --sidebar-primary: oklch(0.24 0.06 240); /* #003153 */
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.274 0.006 286.033);
   --sidebar-accent-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
Implementation of SCRUM-222

update all primary buttons to #003153 color

--- Implementation Plan ---

# Implementation Plan

## Conceptual Checklist

- Identify all CSS variables that define primary button colors
- Convert #003153 to oklch color format
- Determine appropriate foreground color for text contrast
- Update both light and dark mode variables
- Consider sidebar-primary for consistency

## Overview

Update the primary button color from current value to #003153 (Prussian Blue) by modifying CSS custom properties in `client/src/index.css`.

## Assumptions and Rules from CLAUDE.md

- **Assumption**: Apply to both light and dark modes unless clarified
- **Assumption**: Update sidebar-primary for consistency
- **Rule (CLAUDE.md)**: Client uses TailwindCSS with Shadcn UI components
- **Rule (CLAUDE.md)**: Run `npm run lint` after changes

## Step-by-Step Implementation

1. **Convert #003153 to oklch format**
   - #003153 ≈ oklch(0.25 0.05 240) (Prussian Blue)
   - Dependencies: None
   - Tools: Color conversion utility

2. **Update `client/src/index.css` - Light Mode**
   - Modify `--primary` in `:root` selector
   - Verify `--primary-foreground` provides sufficient contrast (white/light color should work)
   - File: `client/src/index.css` lines 14-15

3. **Update `client/src/index.css` - Dark Mode**
   - Modify `--primary` in `.dark` selector
   - File: `client/src/index.css` lines 50-51

4. **Update sidebar-primary (if applicable)**
   - Modify `--sidebar-primary` in both selectors for consistency
   - File: `client/src/index.css` lines 35-36, 70-71

5. **Verify and test**
   - Run `npm run lint` in client directory
   - Visual verification of button appearance

## Error Handling and Uncertainties

- **Color contrast**: #003153 is dark, so `--primary-foreground` should be white/light. Current value `oklch(0.985 0 0)` (near-white) should provide good contrast.
- **Dark mode**: In dark mode, the current primary is light (0.985). Using #003153 in dark mode may need different treatment - potentially keep as light or use a lighter variant of the blue.